### PR TITLE
fix: convert money type to i64

### DIFF
--- a/src/tds/codec/column_data/money.rs
+++ b/src/tds/codec/column_data/money.rs
@@ -6,17 +6,17 @@ where
 {
     let res = match len {
         0 => ColumnData::I64(None),
-        4 => ColumnData::I64(Some(src.read_i32_le().await? as i64 / 1e4 as i64)),
-        8 => ColumnData::I64(Some({
+        4 => ColumnData::I64(Some(src.read_i32_le().await? as i64)),
+        8 => {
             let high = src.read_i32_le().await? as i64;
-            let low = src.read_u32_le().await? as i64;
+            let low = src.read_u32_le().await?;
 
-            (high << 32) + low / 1e4 as i64
-        })),
+            ColumnData::I64(Some((high << 32) | low as i64))
+        }
         _ => {
             return Err(Error::Protocol(
                 format!("money: length of {} is invalid", len).into(),
-            ));
+            ))
         }
     };
 

--- a/src/tds/codec/column_data/money.rs
+++ b/src/tds/codec/column_data/money.rs
@@ -5,18 +5,18 @@ where
     R: SqlReadBytes + Unpin,
 {
     let res = match len {
-        0 => ColumnData::F64(None),
-        4 => ColumnData::F64(Some(src.read_i32_le().await? as f64 / 1e4)),
-        8 => ColumnData::F64(Some({
+        0 => ColumnData::I64(None),
+        4 => ColumnData::I64(Some(src.read_i32_le().await? as i64 / 1e4 as i64)),
+        8 => ColumnData::I64(Some({
             let high = src.read_i32_le().await? as i64;
-            let low = src.read_u32_le().await? as f64;
+            let low = src.read_u32_le().await? as i64;
 
-            ((high << 32) as f64 + low) / 1e4
+            (high << 32) + low / 1e4 as i64
         })),
         _ => {
             return Err(Error::Protocol(
                 format!("money: length of {} is invalid", len).into(),
-            ))
+            ));
         }
     };
 


### PR DESCRIPTION
 refer to https://learn.microsoft.com/en-us/sql/t-sql/data-types/money-and-smallmoney-transact-sql?view=sql-server-ver16
The `Money` type is implemented in `i64` in the official documentation, and may lose precision when converted to f64. For example, -922,337,203,685,477.5808 should become -922,337,203,685,477.6 because the mantissa of f64 is only 53 bits.

This pr fix this issue.
