### PR TITLE
fix(decode): use lossy UTF-16 decoding for nvarchar/ntext column data

### DIFF
--- a/src/tds/codec/column_data/string.rs
+++ b/src/tds/codec/column_data/string.rs
@@ -37,7 +37,10 @@ where
             }
 
             let buf: Vec<_> = buf.chunks(2).map(LittleEndian::read_u16).collect();
-            Ok(Some(String::from_utf16(&buf)?.into()))
+            // Use lossy decoding so a single malformed row (e.g. a lone surrogate
+            // produced by upstream tooling) cannot terminate the entire stream.
+            // Invalid code units are replaced with U+FFFD.
+            Ok(Some(String::from_utf16_lossy(&buf).into()))
         }
         _ => Ok(None),
     }

--- a/src/tds/codec/column_data/text.rs
+++ b/src/tds/codec/column_data/text.rs
@@ -45,7 +45,8 @@ where
                 buf.push(src.read_u16_le().await?);
             }
 
-            String::from_utf16(&buf[..])?
+            // Lossy decode: a malformed row must not kill the stream.
+            String::from_utf16_lossy(&buf[..])
         }
     };
 


### PR DESCRIPTION
## Problem

`tiberius` decodes `nvarchar` / `ntext` column data via `String::from_utf16`, which is strict: a single ill-formed UTF-16 sequence (typically a **lone surrogate**) returns `FromUtf16Error` and the entire row decode fails.

SQL Server itself does **not** enforce well-formed UTF-16 in `nvarchar` storage. A row like

```sql
INSERT INTO t VALUES (50, N'lone' + NCHAR(0xD83D));   -- lone high surrogate, no D800-DFFF partner
```

is accepted by the server and then poisons the stream on the client. Real-world ETL tooling, MERGE replication from legacy systems, and CDC pipelines that write back into SQL Server all produce this in practice.

## Why this matters for streaming consumers

For batch-style queries the strict error is at least visible. For **streaming consumers** (CDC backfill in particular) it's much worse:

1. The CDC backfill stream emits rows in PK order until it hits the malformed row.
2. `from_utf16` blows up → the whole `Stream<Item = Result<Row, _>>` terminates.
3. The consumer's reconnect/restart logic re-issues from the last persisted LSN/PK.
4. It hits the same row again → infinite retry loop, zero forward progress.

Reproduced end-to-end against RisingWave's SQL Server CDC connector — backfill never advances past the row containing the lone surrogate.

## Fix

Switch the two **column-data** UTF-16 decode paths to `from_utf16_lossy`. Invalid code units become `U+FFFD`, and the stream survives:

- `src/tds/codec/column_data/string.rs` — `nvarchar` / `nchar` payloads.
- `src/tds/codec/column_data/text.rs` — `ntext` payloads.

This matches the tolerance other CDC connectors (Postgres / MySQL) already give you for malformed text in user data.

## What's intentionally **not** changed

The protocol-level UTF-16 paths stay strict:

- `src/sql_read_bytes.rs`
- `src/tds/codec/token/token_env_change.rs`
- `src/tds/codec/login.rs`

Those decode server-controlled metadata (env-change tokens, login response, identifiers). A bad value there indicates a real TDS protocol violation and should still error loudly.

## Test plan

- [x] `cargo build` (lib) clean against `rustls,sql-browser-tokio,chrono,tds73`.
- [x] Reproduced the bug downstream against RisingWave SQL Server CDC backfill: with this patch, a 101-row table containing one lone-surrogate row finishes backfill (101/101); the malformed character lands as U+FFFD instead of stalling the stream. *(repro to be re-run after RW bumps the rev — see follow-up.)*